### PR TITLE
fix(version): add trame_client.__version__

### DIFF
--- a/trame_client/__init__.py
+++ b/trame_client/__init__.py
@@ -1,0 +1,3 @@
+from .utils.version import get_version
+
+__version__ = get_version("trame-client")

--- a/trame_client/utils/version.py
+++ b/trame_client/utils/version.py
@@ -1,0 +1,20 @@
+try:
+    # Use importlib metadata if available (python >=3.8)
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # No importlib metadata. Try to use pkg_resources instead.
+    from pkg_resources import (
+        get_distribution,
+        DistributionNotFound as PackageNotFoundError,
+    )
+
+    def version(x):
+        return get_distribution(x).version
+
+
+def get_version(package_name):
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        # package is not installed
+        pass


### PR DESCRIPTION
The `get_version()` function added here will also be used in all other trame-* packages.

Partially addresses Kitware/trame#183