### PR TITLE
Allow style attribute to be a dictionary

### DIFF
--- a/trame_client/widgets/core.py
+++ b/trame_client/widgets/core.py
@@ -272,6 +272,10 @@ class AbstractElement:
         )
         self._event_names = kwargs.get("__events", []) + SHARED_EVENTS
 
+        style = kwargs.get("style", None)
+        if type(style) is dict:
+            kwargs["style"] = " ".join([f"{k}: {v};" for k, v in style.items()])
+
         self._attributes = {}
         self._py_attr = kwargs
         self._children = []


### PR DESCRIPTION
For example:
```
html.Div(
    style={
        "width": "10px",
        "display": "flex",
       "flex-direction": "column",
    }
)
```