### PR TITLE
fix(numpy): remove np.float_ and np.complex_ for compatibility with numpy 2.0

### DIFF
--- a/trame_client/encoders/numpy.py
+++ b/trame_client/encoders/numpy.py
@@ -1,4 +1,5 @@
 import json
+
 import numpy as np
 
 
@@ -24,10 +25,10 @@ class NumpyEncoder(json.JSONEncoder):
         ):
             return int(obj)
 
-        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
 
-        elif isinstance(obj, (np.complex_, np.complex64, np.complex128)):
+        elif isinstance(obj, (np.complex64, np.complex128)):
             return {"real": obj.real, "imag": obj.imag}
 
         elif isinstance(obj, (np.ndarray,)):


### PR DESCRIPTION
This PR removes `np.float_` and `np.complex_` that have been removed in numpy 2.0 (see [NumPy release notes](https://numpy.org/devdocs/release/2.0.0-notes.html)).
- `np.float64` must be used instead of `np.float_`
- `np.complex128` must be used instead of `np.complex_`