### PR TITLE
fix(layout): provide a display_cell method for google-colab iframe display

### DIFF
--- a/trame_client/ui/core.py
+++ b/trame_client/ui/core.py
@@ -336,3 +336,14 @@ You should run the following code before displaying a layout.
                 display(self.ipywidget)
             except ImportError:
                 display_html(self._jupyter_content(), raw=True)
+
+    async def display_cell(self, *, height=None, width=None):
+        from IPython.display import clear_output
+
+        height = height or "100%"
+        width = width or "100%"
+
+        self.iframe_style = f"border: none; width: {width}{css_unit(width)}; height: {height}{css_unit(height)};"
+        await self.ready
+        clear_output(wait=True)
+        self._ipython_display_()


### PR DESCRIPTION
- Move logic from trame-common to abstract layout on starting the iframe display in jupyter and google-colab context