### PR TITLE
Memory leak: `window.onbeforeunload` listener added for every new connection

### DIFF
--- a/js-lib/package.json
+++ b/js-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitware/trame",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "./dist/trame.umd.js",
   "unpkg": "./dist/trame.umd.js",

--- a/js-lib/src/trame.js
+++ b/js-lib/src/trame.js
@@ -160,9 +160,6 @@ export class Trame {
       this.client?.getRemote()?.Trame.unsubscribe(wslinkSub),
     );
     this.client?.getRemote()?.Trame?.lifeCycleUpdate("client_connected");
-    window.addEventListener("beforeunload", () =>
-      this.client?.getRemote()?.Trame?.lifeCycleUpdate("client_exited"),
-    );
 
     return this.config;
   }
@@ -172,6 +169,7 @@ export class Trame {
    */
   disconnect() {
     if (this.isConnected()) {
+      this.client.getRemote()?.Trame?.lifeCycleUpdate("client_exited");
       this.client.disconnect(0);
     }
   }
@@ -188,6 +186,7 @@ export class Trame {
    */
   exit(timeout = 60) {
     if (this.isConnected()) {
+      this.client.getRemote()?.Trame?.lifeCycleUpdate("client_exited");
       this.client.disconnect(timeout);
     }
   }


### PR DESCRIPTION
@jourdain With every new `Trame` connection made in JavaScript, a `window.onbeforeunload` event listener is added, that attempts to phone home:

https://github.com/Kitware/trame-client/blob/93458287527809c26ef00b755a5b61c8d9ce33ac/js-lib/src/trame.js#L163-L165

This leaks an un-disposable Trame object every time the listener is added.

In other words, even if you call `trame.exit()` and `trame.disconnect()` on your connection when you're done, and `null` out all of your references, the `Trame` object is still lives on in the global scope.

The better way to do this is to send a "heartbeat" signal periodically to the server, to tell the server that the connection is still active. If a heartbeat is not received after a time limit, the server should then consider the client to be de-facto disconnected.

This PR removes the `beforeunload` listener. I have not investigated on whether a heartbeat is being sent already so I'm not sure if there is also server-side work that needs to be done.